### PR TITLE
Add missing properties to Typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,9 @@ declare module 'react-native-fullwidth-image' {
 	type Props = {
 		style?: StyleProp<ImageStyle>,
 		source: ImageSourcePropType,
+		width?: number;
+		height?: number;
+		ratio?: number;
 		onLoad?: (event: NativeSyntheticEvent<ImageLoadEventData>) => void,
 		onLoadEnd?: () => void,
 		onLoadStart?: () => void


### PR DESCRIPTION
Width, height and ratio are missing in the Typescript typings.

@wassgha 